### PR TITLE
Fix MCP protocol compliance: use 'notifications/initialized' method

### DIFF
--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -193,8 +193,8 @@ func (s *Server) registerDefaultHandlers() {
 	if s.GetHandler("initialize") == nil {
 		s.RegisterHandler("initialize", s.handleInitialize)
 	}
-	if s.GetNotificationHandler("initialized") == nil {
-		s.RegisterNotificationHandler("initialized", s.handleInitialized)
+	if s.GetNotificationHandler("notifications/initialized") == nil {
+		s.RegisterNotificationHandler("notifications/initialized", s.handleInitialized)
 	}
 	if s.GetHandler("tools/list") == nil {
 		s.RegisterHandler("tools/list", s.handleToolsList)

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -142,7 +142,7 @@ func TestServerStart(t *testing.T) {
 		t.Error("Initialize handler not registered")
 	}
 
-	if _, exists := server.notifications["initialized"]; !exists {
+	if _, exists := server.notifications["notifications/initialized"]; !exists {
 		t.Error("Initialized notification handler not registered")
 	}
 }


### PR DESCRIPTION
## Problem

The MCP server framework was registering a notification handler for `"initialized"` instead of the correct `"notifications/initialized"` method as defined in the MCP specification. This caused protocol compliance issues where clients sending the proper `"notifications/initialized"` notification would receive "No handler for notification" errors.

## Solution

Updated the framework to use the correct method name `"notifications/initialized"` as specified in the MCP protocol.

## Changes

- **server.go**: Changed notification handler registration from `"initialized"` to `"notifications/initialized"`
- **server_test.go**: Updated test to check for the correct method name

## References

- [MCP TypeScript SDK specification](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/types.ts#L320-L323)
- [MCP reference servers](https://github.com/modelcontextprotocol/servers) use the same pattern

## Testing

- All existing tests pass
- The change maintains backward compatibility for any custom handlers
- Protocol compliance is now correct according to MCP specification

This fix resolves the "No handler for notification: notifications/initialized" error that users were experiencing when using MCP clients that correctly implement the protocol.